### PR TITLE
Add `jupyter-server` and `notebook` to the build environment

### DIFF
--- a/environment-wasm-build.yml
+++ b/environment-wasm-build.yml
@@ -5,5 +5,7 @@ dependencies:
   - cmake
   - emsdk >=3.1.46
   - empack >=3.2.0
+  - jupyter-server  # to enable contents
   - jupyterlite
   - jupyterlite-xeus
+  - notebook >=7,<8  # to include the extension to switch between JupyterLab and Notebook

--- a/environment-wasm-build.yml
+++ b/environment-wasm-build.yml
@@ -5,7 +5,7 @@ dependencies:
   - cmake
   - emsdk >=3.1.46
   - empack >=3.2.0
-  - jupyter-server  # to enable contents
+  - jupyter_server  # to enable contents
   - jupyterlite
   - jupyterlite-xeus
   - notebook >=7,<8  # to include the extension to switch between JupyterLab and Notebook


### PR DESCRIPTION
This should help fix the missing contents in the deployed site: https://derthorsten.github.io/xeus-javascript/lab/index.html

As noticed in https://github.com/DerThorsten/xeus-javascript/actions/runs/7583515865/job/20655314743

![image](https://github.com/DerThorsten/xeus-javascript/assets/591645/3d736387-a26e-4da8-a0d0-5e91504913d3)

The `notebook` dependency should bring the following UI items to switch between lab and notebook:

![image](https://github.com/DerThorsten/xeus-javascript/assets/591645/7c729025-40e6-49b4-a68f-19145f87436e)
