### PR TITLE
Depend on `jupyterlite-core` instead of `jupyterlite`

### DIFF
--- a/environment-wasm-build.yml
+++ b/environment-wasm-build.yml
@@ -6,6 +6,6 @@ dependencies:
   - emsdk >=3.1.46
   - empack >=3.2.0
   - jupyter_server  # to enable contents
-  - jupyterlite
+  - jupyterlite-core
   - jupyterlite-xeus
   - notebook >=7,<8  # to include the extension to switch between JupyterLab and Notebook


### PR DESCRIPTION
This will help avoid having 2 JS kernels on the demo page, which could be confusing to some users.

The reason the deployment included the `JavaScript (Web Worker)` kernel is because the `jupyterlite` metapackage still depends on `jupyterlite-javascript-kernel` at the moment. Although this won't be the case in the future: https://github.com/jupyterlite/jupyterlite/pull/1313